### PR TITLE
update Guzzle to 6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 SIL International
+Copyright (c) 2020 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,13 @@
   "keywords": ["smartsheet"],
   "license": "MIT",
   "require": {
-    "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^5.3.1",
-    "guzzlehttp/guzzle-services": "*",
-    "guzzlehttp/retry-subscriber": "*",
-    "guzzlehttp/log-subscriber": "*"
+    "php": ">=7.2.0",
+    "guzzlehttp/guzzle-services": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "ext-json": "*",
+    "phpunit/phpunit": "~4.0",
+    "roave/security-advisories": "dev-master"
   },
   "authors": [
     {


### PR DESCRIPTION
required changes:
- `guzzlehttp/retry-subscriber` was removed, so no automatic API retries
- http client is now immutable, so credentials are applied to config before client creation 
- `setConfig` changed how arguments are passed (slash-separated to nested array)
- test mocks are created differently